### PR TITLE
Add placeholders for career and academic info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # filippobounous.github.io
+
+This repository hosts my personal GitHub Pages site. It currently displays a list of my projects in CSV form and includes contact links. The landing page shows placeholders for my current title, company, and academic experience.
+
+The page also links to my CV. It notes when the file was last updated, but you can contact me for a more recent copy.
+
+Feel free to open issues or pull requests if you spot something wrong!

--- a/cv.pdf
+++ b/cv.pdf
@@ -1,0 +1,2 @@
+This CV was last updated on July 4, 2025.
+Contact me for a current version.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Filippo Bounous</title>
+  <style>
+    body { font-family: monospace; margin: 2rem; }
+    pre { background: #f7f7f7; padding: 1rem; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 0.5rem 0; }
+  </style>
+</head>
+<body>
+  <h1>Filippo Bounous</h1>
+  <p><em>Your Title Here at Your Company Here</em></p>
+  <p>Contact: <a href="mailto:filippo@example.com">filippo@example.com</a></p>
+  <ul>
+    <li><a href="https://github.com/filippobounous">GitHub</a></li>
+    <li><a href="https://www.linkedin.com/in/filippobounous">LinkedIn</a></li>
+    <li><a href="cv.pdf">Download CV</a> (Last updated: 2025-07-04)</li>
+  </ul>
+
+  <p>Please contact me if you need the most recent version.</p>
+
+  <h2>Academic Experience</h2>
+  <p>Placeholder for degree and school.</p>
+
+  <h2>Projects</h2>
+  <pre>
+Project,Description,Link
+SampleApp,A demo application,https://github.com/filippo/sampleapp
+ResearchTool,A set of research scripts,https://github.com/filippo/research-tool
+PersonalWebsite,The site you're looking at,https://filippobounous.github.io
+  </pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- describe current job and education placeholders in README
- show title/company and academic experience on landing page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686789c0b54083258929c4f859701cd1